### PR TITLE
RGB変換プログラム、テストプログラムの作成

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,1 +1,4 @@
+--color
 --require spec_helper
+--format documentation
+--order random

--- a/chapter04/rgb.rb
+++ b/chapter04/rgb.rb
@@ -8,7 +8,7 @@ def to_hex(r, g, b)
 end
 
 # RGBカラーを表す16 進数文字列を受け取り、R、G、Bのそれぞれを10進数の整数に変換した値を配列として返す。
-# @param [String] hex '#' + RGBカラーを表す16進数文字列
+# @param hex[String] '#' + RGBカラーを表す16進数文字列
 # @return [Array] R、G、Bのそれぞれを10進数の整数に変換した値を配列
 def to_ints(hex)
   r, g, b = hex[1..2], hex[3..4], hex[5..6]

--- a/chapter04/rgb.rb
+++ b/chapter04/rgb.rb
@@ -1,0 +1,8 @@
+def to_hex(r, g, b)
+  [r, g, b].inject('#') { |hex, n| hex += n.to_s(16).rjust(2, '0')}
+end
+
+def to_ints(hex)
+  r, g, b = hex[1..2], hex[3..4], hex[5..6]
+  [r, g, b].map { |s| s.hex }
+end

--- a/chapter04/rgb.rb
+++ b/chapter04/rgb.rb
@@ -12,5 +12,5 @@ end
 # @return [Array] R、G、Bのそれぞれを10進数の整数に変換した値を配列
 def to_ints(hex)
   r, g, b = hex[1..2], hex[3..4], hex[5..6]
-  [r, g, b].map { |s| s.hex }
+  [r, g, b].map(&:hex)
 end

--- a/chapter04/rgb.rb
+++ b/chapter04/rgb.rb
@@ -1,7 +1,15 @@
+# 3つの整数を受け取り、それぞれを16進数に変換した文字列を返す。（先頭に'#'を付ける）
+# @param r[Integer] Rの値
+# @param g[Integer] Gの値
+# @param b[Integer] Bの値
+# @return [String] r,g,bを16進数に変換し、結合した文字列（先頭に'#'を付ける）
 def to_hex(r, g, b)
   [r, g, b].inject('#') { |hex, n| hex += n.to_s(16).rjust(2, '0')}
 end
 
+# RGBカラーを表す16 進数文字列を受け取り、R、G、Bのそれぞれを10進数の整数に変換した値を配列として返す。
+# @param [String] hex '#' + RGBカラーを表す16進数文字列
+# @return [Array] R、G、Bのそれぞれを10進数の整数に変換した値を配列
 def to_ints(hex)
   r, g, b = hex[1..2], hex[3..4], hex[5..6]
   [r, g, b].map { |s| s.hex }

--- a/chapter04/rgb_test.rb
+++ b/chapter04/rgb_test.rb
@@ -1,0 +1,16 @@
+require 'minitest/autorun'
+require_relative './rgb'
+
+class RgbTest < Minitest::Test
+  def test_to_hex
+    assert_equal '#000000', to_hex(0, 0, 0)
+    assert_equal '#ffffff', to_hex(255, 255, 255)
+    assert_equal '#043c78', to_hex(4, 60, 120)
+  end
+
+  def test_to_ints
+    assert_equal [0, 0, 0], to_ints('#000000')
+    assert_equal [255, 255, 255], to_ints('#ffffff')
+    assert_equal [4, 60, 120], to_ints('#043c78')
+  end
+end

--- a/spec/rgb_spec.rb
+++ b/spec/rgb_spec.rb
@@ -25,4 +25,3 @@ RSpec.describe 'Conversion RGB' do
     end
   end
 end
-

--- a/spec/rgb_spec.rb
+++ b/spec/rgb_spec.rb
@@ -2,25 +2,25 @@ require_relative '../chapter04/rgb'
 
 RSpec.describe 'Conversion RGB' do
   describe '#to_hex' do
-    it "(0,0,0) -> #000000" do
+    it '(0,0,0) -> #000000' do
       expect(to_hex(0, 0, 0)).to eq '#000000'
     end
-    it "(255, 255, 255) -> #ffffff" do
+    it '(255, 255, 255) -> #ffffff' do
       expect(to_hex(255, 255, 255)).to eq '#ffffff'
     end
-    it "(4, 60, 120) -> #043c78" do
+    it '(4, 60, 120) -> #043c78' do
       expect(to_hex(4, 60, 120)).to eq '#043c78'
     end
    end
 
-  describe "#to_ints" do
-    it "#000000 -> [0, 0, 0]" do
+  describe '#to_ints' do
+    it '#000000 -> [0, 0, 0]' do
       expect(to_ints('#000000')).to eq [0, 0, 0]
     end
-    it "#ffffff -> [255, 255, 255]" do
+    it '#ffffff -> [255, 255, 255]' do
       expect(to_ints('#ffffff')).to eq [255, 255, 255]
     end
-    it "#043c78 -> [4, 60, 120]" do
+    it '#043c78 -> [4, 60, 120]' do
       expect(to_ints('#043c78')).to eq [4, 60, 120]
     end
   end

--- a/spec/rgb_spec.rb
+++ b/spec/rgb_spec.rb
@@ -1,15 +1,28 @@
 require_relative '../chapter04/rgb'
 
 RSpec.describe 'Conversion RGB' do
-  it "test_to_hex" do
-    expect(to_hex(0, 0, 0)).to eq '#000000'
-    expect(to_hex(255, 255, 255)).to eq '#ffffff'
-    expect(to_hex(4, 60, 120)).to eq '#043c78'
-  end
+  describe '#to_hex' do
+    it "(0,0,0) -> #000000" do
+      expect(to_hex(0, 0, 0)).to eq '#000000'
+    end
+    it "(255, 255, 255 -> #ffffff" do
+      expect(to_hex(255, 255, 255)).to eq '#ffffff'
+    end
+    it "(4, 60, 120) -> #043c78" do
+      expect(to_hex(4, 60, 120)).to eq '#043c78'
+    end
+   end
 
-  it "test_to_ints" do
-    expect(to_ints('#000000')).to eq [0, 0, 0]
-    expect(to_ints('#ffffff')).to eq [255, 255, 255]
-    expect(to_ints('#043c78')).to eq [4, 60, 120]
+  describe "#to_ints" do
+    it "#000000 -> [0, 0, 0]" do
+      expect(to_ints('#000000')).to eq [0, 0, 0]
+    end
+    it "#ffffff -> [255, 255, 255]" do
+      expect(to_ints('#ffffff')).to eq [255, 255, 255]
+    end
+    it "#043c78 -> [4, 60, 120]" do
+      expect(to_ints('#043c78')).to eq [4, 60, 120]
+    end
   end
 end
+

--- a/spec/rgb_spec.rb
+++ b/spec/rgb_spec.rb
@@ -1,0 +1,15 @@
+require_relative '../chapter04/rgb'
+
+RSpec.describe 'Conversion RGB' do
+  it "test_to_hex" do
+    expect(to_hex(0, 0, 0)).to eq '#000000'
+    expect(to_hex(255, 255, 255)).to eq '#ffffff'
+    expect(to_hex(4, 60, 120)).to eq '#043c78'
+  end
+
+  it "test_to_ints" do
+    expect(to_ints('#000000')).to eq [0, 0, 0]
+    expect(to_ints('#ffffff')).to eq [255, 255, 255]
+    expect(to_ints('#043c78')).to eq [4, 60, 120]
+  end
+end

--- a/spec/rgb_spec.rb
+++ b/spec/rgb_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe 'Conversion RGB' do
     it "(0,0,0) -> #000000" do
       expect(to_hex(0, 0, 0)).to eq '#000000'
     end
-    it "(255, 255, 255 -> #ffffff" do
+    it "(255, 255, 255) -> #ffffff" do
       expect(to_hex(255, 255, 255)).to eq '#ffffff'
     end
     it "(4, 60, 120) -> #043c78" do

--- a/spec/rgb_spec.rb
+++ b/spec/rgb_spec.rb
@@ -5,9 +5,11 @@ RSpec.describe 'Conversion RGB' do
     it '(0,0,0) -> #000000' do
       expect(to_hex(0, 0, 0)).to eq '#000000'
     end
+
     it '(255, 255, 255) -> #ffffff' do
       expect(to_hex(255, 255, 255)).to eq '#ffffff'
     end
+
     it '(4, 60, 120) -> #043c78' do
       expect(to_hex(4, 60, 120)).to eq '#043c78'
     end
@@ -17,9 +19,11 @@ RSpec.describe 'Conversion RGB' do
     it '#000000 -> [0, 0, 0]' do
       expect(to_ints('#000000')).to eq [0, 0, 0]
     end
+
     it '#ffffff -> [255, 255, 255]' do
       expect(to_ints('#ffffff')).to eq [255, 255, 255]
     end
+    
     it '#043c78 -> [4, 60, 120]' do
       expect(to_ints('#043c78')).to eq [4, 60, 120]
     end


### PR DESCRIPTION
## RGB変換プログラムの仕様

### to_hexメソッド（10進数を16 進数に変換）

- 3つの整数を受け取り、それぞれを16進数に変換した文字列を返す。
- 文字列の先頭には"#"をつける。

### to_intsメソッド（16進数を10 進数に変換）
- RGBカラーを表す16 進数文字列を受け取り、R、G、Bのそれぞれを10進数の整数に変換した値を配列として返す。

## やったこと

- 上記の2つのメソッドのテストコード（Minitest）を実装した、rgb_test.rbを作成。
- 上記の2つのメソッドを実装した、rgb.rbを作成。 
- rgb_test.rbをRSpecで書き換えたrgb_spec.rbを作成。


## 動作確認

### 1. Minitest
- `$ ruby chapter04/rgb_test.rb`を実行し、下記の出力を確認の上、全てのテストがパスしていることを確認する。
```
2 runs, 6 assertions, 0 failures, 0 errors, 0 skips
```

### 2. RSpec
- `$ bundle exec rspec spec/rgb_spec.rb`を実行し、下記の出力を確認の上、全てのテストがパスしていることを確認する。（テスト順はランダム）
```
Conversion RGB
  #to_ints
    #ffffff -> [255, 255, 255]
    #043c78 -> [4, 60, 120]
    #000000 -> [0, 0, 0]
  #to_hex
    (0,0,0) -> #000000
    (4, 60, 120) -> #043c78
    (255, 255, 255 -> #ffffff

…（省略）…

6 examples, 0 failures
```