### PR TITLE
ハッシュ記法変換プログラム、テストプログラムの作成

### DIFF
--- a/chapter06/convert_hash_syntax.rb
+++ b/chapter06/convert_hash_syntax.rb
@@ -1,0 +1,9 @@
+def convert_hash_syntax(syntax)
+  <<~TEXT
+  {
+    name: 'Alice',
+    age: 20,
+    gender: :female
+  }
+  TEXT
+end

--- a/chapter06/convert_hash_syntax.rb
+++ b/chapter06/convert_hash_syntax.rb
@@ -1,9 +1,8 @@
+# =>を使った記法から、=>を使わずコロン(:)を右側に付ける記法に変換する
+# 変換後の:の後のスペースは1個に統一する
+# 
+# @param syntax [String] 変換元のハッシュ文字列
+# @return [String] 変換後のハッシュ文字列
 def convert_hash_syntax(syntax)
-  <<~TEXT
-  {
-    name: 'Alice',
-    age: 20,
-    gender: :female
-  }
-  TEXT
+  syntax.gsub(/:(?<key>\w+)\s*=>\s*/,'\k<key>: ')
 end

--- a/chapter06/convert_hash_syntax_test.rb
+++ b/chapter06/convert_hash_syntax_test.rb
@@ -5,9 +5,9 @@ class ConvertHashSyntaxTest < MiniTest::Test
   def test_convert_hash_syntax
     old_syntax = <<~TEXT
     {
-      :name=> 'Alice',
+      :name => 'Alice',
       :age=>20,
-      :gender => :female
+      :gender  => :female
     }
     TEXT
     new_syntax =<<~TEXT

--- a/chapter06/convert_hash_syntax_test.rb
+++ b/chapter06/convert_hash_syntax_test.rb
@@ -1,0 +1,22 @@
+require 'minitest/autorun'
+require_relative './convert_hash_syntax'
+
+class ConvertHashSyntaxTest < MiniTest::Test
+  def test_convert_hash_syntax
+    old_syntax = <<~TEXT
+    {
+      :name=> 'Alice',
+      :age=>20,
+      :gender => :female
+    }
+    TEXT
+    new_syntax =<<~TEXT
+    {
+      name: 'Alice',
+      age: 20,
+      gender: :female
+    }
+    TEXT
+    assert_equal new_syntax, convert_hash_syntax(old_syntax)
+  end
+end

--- a/chapter06/convert_hash_syntax_test.rb
+++ b/chapter06/convert_hash_syntax_test.rb
@@ -10,6 +10,7 @@ class ConvertHashSyntaxTest < MiniTest::Test
       :gender  => :female
     }
     TEXT
+
     new_syntax =<<~TEXT
     {
       name: 'Alice',
@@ -17,6 +18,7 @@ class ConvertHashSyntaxTest < MiniTest::Test
       gender: :female
     }
     TEXT
+    
     assert_equal new_syntax, convert_hash_syntax(old_syntax)
   end
 end

--- a/spec/convert_hash_syntax_spec.rb
+++ b/spec/convert_hash_syntax_spec.rb
@@ -5,9 +5,9 @@ RSpec.describe 'Convert Hash Syntax' do
     it '=>を使った記法のハッシュ文字列を変換すると、=>を使わずコロン(:)を右側に付けたハッシュ文字列になること' do
       old_syntax = <<~TEXT
       {
-        :name=> 'Alice',
+        :name => 'Alice',
         :age=>20,
-        :gender => :female
+        :gender  => :female
       }
       TEXT
       new_syntax = <<~TEXT

--- a/spec/convert_hash_syntax_spec.rb
+++ b/spec/convert_hash_syntax_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe 'Convert Hash Syntax' do
       {
         :name=> 'Alice',
         :age=>20,
-        :gender => :female 
+        :gender => :female
       }
       TEXT
       new_syntax = <<~TEXT

--- a/spec/convert_hash_syntax_spec.rb
+++ b/spec/convert_hash_syntax_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe 'Convert Hash Syntax' do
         :gender  => :female
       }
       TEXT
+
       new_syntax = <<~TEXT
       {
         name: 'Alice',
@@ -17,6 +18,7 @@ RSpec.describe 'Convert Hash Syntax' do
         gender: :female
       }
       TEXT
+      
       expect(convert_hash_syntax(old_syntax)).to eq new_syntax
     end
   end

--- a/spec/convert_hash_syntax_spec.rb
+++ b/spec/convert_hash_syntax_spec.rb
@@ -2,7 +2,7 @@ require_relative '../chapter06/convert_hash_syntax'
 
 RSpec.describe 'Convert Hash Syntax' do
   describe '#convert_hash_syntax' do
-    it '古い記法のHash文字列を変換すると、新しい記法のHash文字列になること' do
+    it '=>を使った記法のハッシュ文字列を変換すると、=>を使わずコロン(:)を右側に付けたハッシュ文字列になること' do
       old_syntax = <<~TEXT
       {
         :name=> 'Alice',

--- a/spec/convert_hash_syntax_spec.rb
+++ b/spec/convert_hash_syntax_spec.rb
@@ -2,7 +2,7 @@ require_relative '../chapter06/convert_hash_syntax'
 
 RSpec.describe 'Convert Hash Syntax' do
   describe '#convert_hash_syntax' do
-    it '=>を使った記法のハッシュ文字列を変換すると、=>を使わずコロン(:)を右側に付けたハッシュ文字列になること' do
+    it '=> を使ったハッシュ記法から、後ろに : を置くハッシュ記法に変換すること' do
       old_syntax = <<~TEXT
       {
         :name => 'Alice',
@@ -18,7 +18,7 @@ RSpec.describe 'Convert Hash Syntax' do
         gender: :female
       }
       TEXT
-      
+
       expect(convert_hash_syntax(old_syntax)).to eq new_syntax
     end
   end

--- a/spec/convert_hash_syntax_spec.rb
+++ b/spec/convert_hash_syntax_spec.rb
@@ -1,0 +1,23 @@
+require_relative '../chapter06/convert_hash_syntax'
+
+RSpec.describe 'Convert Hash Syntax' do
+  describe '#convert_hash_syntax' do
+    it '古い記法のHash文字列を変換すると、新しい記法のHash文字列になること' do
+      old_syntax = <<~TEXT
+      {
+        :name=> 'Alice',
+        :age=>20,
+        :gender => :female 
+      }
+      TEXT
+      new_syntax = <<~TEXT
+      {
+        name: 'Alice',
+        age: 20,
+        gender: :female
+      }
+      TEXT
+      expect(convert_hash_syntax(old_syntax)).to eq new_syntax
+    end
+  end
+end


### PR DESCRIPTION
## ハッシュ記法変換の仕様

### `#convert_hash_syntax`

- =>を使った記法から、=>を使わずコロン(:)を右側に付ける記法に正規表現を用いて変換する
- 変換後の:の後のスペースは1個に統一する

## やったこと

1. `#convert_hash_syntax`の動作を確認するためのspecファイルを作成
2. RSpecテストがパスするための`#convert_hash_syntax`を仮実装
3. RSpecテストがパスしたことを確認し、`#convert_hash_syntax`を本実装
4. RSpecテストがパスすることを確認
5. `#convert_hash_syntax`が正しく動作することを確認するテストファイル(Minitest)を作成
6. Minitestのテストがパスすることを確認

## 動作確認

### 1. Minitest
- `$ ruby chapter06/convert_hash_syntax_test.rb`を実行し、下記の出力を確認の上、全てのテストがパスしていることを確認する。
```
1 runs, 1 assertions, 0 failures, 0 errors, 0 skips
```

### 2. RSpec
- `$ bundle exec rspec spec/convert_hash_syntax_spec.rb`を実行し、下記の出力を確認の上、全てのテストがパスしていることを確認する。
```
Convert Hash Syntax
  #convert_hash_syntax
    =>を使った記法のハッシュ文字列を変換すると、=>を使わずコロン(:)を右側に付けたハッシュ文字列になること

…（省略）…

1 example, 0 failures
```

## その他

- テストの入力文字列が間違っていることに複数回気づき修正したため、コミット回数が少し多くなっています。